### PR TITLE
add buffer method

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ luarocks install --from=http://mah0x211.github.io/rocks/ magic
 ### instance methods
     mgc:file( path:string );
     mgc:descriptor( fd:integer );
+    mgc:buffer( buffer:string );
     mgc:error();
     mgc:setflags( [...:constants] );
     mgc:load( path:string );

--- a/src/magic.c
+++ b/src/magic.c
@@ -72,6 +72,17 @@ static int descriptor_lua( lua_State *L )
     return 1;
 }
 
+static int buffer_lua( lua_State *L )
+{
+    size_t size;
+    lmagic_t *magic = luaL_checkudata( L, 1, MODULE_MT );
+    const char *buf = luaL_checklstring( L, 2, &size );
+
+    lua_pushstring(L, magic_buffer( magic->mgc, buf, size ) );
+
+    return 1;
+}
+
 static int error_lua( lua_State *L )
 {
     lmagic_t *magic = luaL_checkudata( L, 1, MODULE_MT );
@@ -271,6 +282,7 @@ LUALIB_API int luaopen_magic( lua_State *L )
         // method
         { "file", file_lua },
         { "descriptor", descriptor_lua },
+        { "buffer", buffer_lua },
         { "error", error_lua },
         { "setFlags", setflags_lua },
         { "load", load_lua },


### PR DESCRIPTION
Expose `buffer` method to lua API:

```
const char *
     magic_buffer(magic_t cookie, const void *buffer, size_t length);
```
http://man7.org/linux/man-pages/man3/libmagic.3.html